### PR TITLE
allow top level custom fields when reporting exceptions

### DIFF
--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -27,7 +27,7 @@ defmodule Rollbax.Item do
     if map_size(meta) == 0 do
       data
     else
-      Map.put(data, "custom", meta)
+      Map.merge(data, meta)
     end
   end
 end

--- a/test/rollbax/client_test.exs
+++ b/test/rollbax/client_test.exs
@@ -14,13 +14,15 @@ defmodule Rollbax.ClientTest do
   end
 
   test "post payload" do
-    :ok = Client.emit(:error, "pass", %{meta: "OK"})
+    :ok = Client.emit(:error, "pass", %{meta: "OK", person: %{id: 123}})
     assert_receive {:api_request, body}
-    assert body =~ "access_token\":\"token1"
-    assert body =~ "environment\":\"test"
-    assert body =~ "level\":\"error"
-    assert body =~ "body\":\"pass"
-    assert body =~ "meta\":\"OK"
+    decoded_body = Poison.decode!(body)
+    assert decoded_body["access_token"] == "token1"
+    assert decoded_body["data"]["environment"] == "test"
+    assert decoded_body["data"]["level"] == "error"
+    assert decoded_body["data"]["body"] == %{"message" => %{"body" => "pass"}}
+    assert decoded_body["data"]["meta"] == "OK"
+    assert decoded_body["data"]["person"] == %{"id" => 123}
   end
 
   test "mass sending" do


### PR DESCRIPTION
this makes it possible to use additional data that rollbar
understands the schema of. rollbar knows what "request" or "person"
mean for example if they appear in the correct place.
if this gets merged i'll probably also release the plug that i use to report phoenix errors to rollbar.