### PR TITLE
Refactor a function in Rollbar.Notifier

### DIFF
--- a/lib/rollbax/notifier.ex
+++ b/lib/rollbax/notifier.ex
@@ -31,14 +31,8 @@ defmodule Rollbax.Notifier do
 
   defp post_event(level, {Logger, msg, _ts, meta}, keys) do
     msg = IO.chardata_to_string(msg)
-    meta = take_into_map(meta, keys)
+    meta = Map.take(meta, keys)
     Rollbax.Client.emit(level, msg, meta)
-  end
-
-  defp take_into_map(metadata, keys) do
-    Enum.reduce metadata, %{}, fn({key, val}, acc) ->
-      if key in keys, do: Map.put(acc, key, val), else: acc
-    end
   end
 
   defp configure(opts) do


### PR DESCRIPTION
The `take_into_map/2` function did exactly what `Map.take/2` does, so I replaced it with `Map.take/2`. `Map.take/2` is available since v1.0 (http://elixir-lang.org/docs/v1.0/elixir/Map.html#take/2), so no problems around that.