### PR TITLE
Decode Rollbax JSON responses

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -55,7 +55,7 @@ defmodule RollbarAPI do
     {:ok, body, conn} = read_body(conn)
     :timer.sleep(30)
     send test, {:api_request, body}
-    send_resp(conn, 200, "OK")
+    send_resp(conn, 200, "{}")
   end
 
   def call(conn, _test) do


### PR DESCRIPTION
Also, log an error when the response contains errors so that the user is likely notified of this.

Should close #24.

\cc @lexmag 