### PR TITLE
Use Logger metadata in "body" instead of "custom"

### DIFF
--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -31,8 +31,8 @@ defmodule Rollbax.Item do
     end)
   end
 
-  def message_to_body(message) do
-    %{"message" => %{"body" => message}}
+  def message_to_body(message, meta) do
+    %{"message" => Map.put(meta, "body", message)}
   end
 
   def exception_to_body(kind, value, stacktrace) do

--- a/lib/rollbax/logger.ex
+++ b/lib/rollbax/logger.ex
@@ -43,9 +43,9 @@ defmodule Rollbax.Logger do
 
   defp post_event(level, {Logger, message, event_time, meta}, keys) do
     event_unix_time = event_time_to_unix(event_time)
-    body = Rollbax.Item.message_to_body(IO.chardata_to_string(message))
-    custom = Keyword.take(meta, keys) |> Enum.into(%{})
-    Rollbax.Client.emit(level, event_unix_time, body, custom, %{})
+    meta = Keyword.take(meta, keys) |> Enum.into(%{})
+    body = Rollbax.Item.message_to_body(IO.chardata_to_string(message), meta)
+    Rollbax.Client.emit(level, event_unix_time, body, %{}, %{})
   end
 
   defp configure(opts) do


### PR DESCRIPTION
@lexmag I think metadata from logged messages belongs alongside the message. In [the Rollbar docs](https://rollbar.com/docs/api/items_post/), when using `"message"` as the body:

```
// Option 3: "message"
// Only one of "trace", "trace_chain", "message", or "crash_report" should be present.
// Presence of a "message" key means that this payload is a log message.
"message": {
  // Required: body
  // The primary message text, as a string
  "body": "Request over threshold of 10 seconds",

  // Can also contain any arbitrary keys of metadata. Their values can be any valid JSON.
  // For example:
  "route": "home#index",
  "time_elapsed": 15.23
},
```