### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/elixir-addicts/rollbax.svg?branch=master "Build Status")](https://travis-ci.org/elixir-addicts/rollbax)
 [![Hex Version](https://img.shields.io/hexpm/v/rollbax.svg "Hex Version")](https://hex.pm/packages/rollbax)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/elixir-addicts/rollbax.svg)](https://beta.hexfaktor.org/github/elixir-addicts/rollbax)
 
 Elixir client for [Rollbar](https://rollbar.com).
 


### PR DESCRIPTION
Hi there,

I wanted to take a moment to pitch my latest project for the Elixir community:

  [![Deps Status](https://beta.hexfaktor.org/badge/all/github/elixir-addicts/rollbax.svg)](https://beta.hexfaktor.org/github/elixir-addicts/rollbax)

This badge shows you an analysis for your dependencies. Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. Just tell me what you think about this idea!