### PR TITLE
Allow globally-set custom fields for Logger backend

### DIFF
--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -25,6 +25,11 @@ defmodule Rollbax do
       are reported; if `false`, `Rollbax.report/5` is basically a no-op; if
       `:log`, exceptions reported with `Rollbax.report/5` are instead logged to
       the shell.
+    * `:custom` - (map) a map of any arbitrary metadata you want to attach to
+      every exception reported by Rollbax. If custom data is specified in an
+      individual call to `Rollbax.report/5` it will be merged with the global
+      data, with the individual data taking precedence in case of conflicts.
+      Defaults to `%{}`.
 
   The `:access_token` and `:environment` options accept a binary or a
   `{:system, "VAR_NAME"}` tuple. When given a tuple like `{:system, "VAR_NAME"}`,
@@ -44,12 +49,13 @@ defmodule Rollbax do
     import Supervisor.Spec
 
     enabled = get_config(:enabled, true)
+    custom  = get_config(:custom, %{})
 
     token = fetch_and_resolve_config(:access_token)
     envt  = fetch_and_resolve_config(:environment)
 
     children = [
-      worker(Rollbax.Client, [token, envt, enabled])
+      worker(Rollbax.Client, [token, envt, enabled, custom])
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/lib/rollbax/client.ex
+++ b/lib/rollbax/client.ex
@@ -22,8 +22,8 @@ defmodule Rollbax.Client do
 
   ## Public API
 
-  def start_link(token, environment, enabled, url \\ @api_url) do
-    state = new(token, environment, url, enabled)
+  def start_link(token, environment, enabled, custom, url \\ @api_url) do
+    state = new(token, environment, url, enabled, custom)
     GenServer.start_link(__MODULE__, state, [name: __MODULE__])
   end
 
@@ -87,8 +87,8 @@ defmodule Rollbax.Client do
 
   ## Helper functions
 
-  defp new(token, environment, url, enabled) do
-    draft = Item.draft(token, environment)
+  defp new(token, environment, url, enabled, custom) do
+    draft = Item.draft(token, environment, custom)
     %__MODULE__{draft: draft, url: url, enabled: enabled}
   end
 

--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -5,7 +5,7 @@ defmodule Rollbax.Item do
   # Refer to https://rollbar.com/docs/api/items_post for documentation on such
   # payload.
 
-  def draft(token, environment) do
+  def draft(token, environment, custom) do
     %{
       "access_token" => token,
       "data" => %{
@@ -17,7 +17,7 @@ defmodule Rollbax.Item do
         "platform" => platform(),
         "notifier" => notifier()
       }
-    }
+    } |> put_custom(custom)
   end
 
   def compose(draft, {level, timestamp, body, custom, occurrence_data}) do
@@ -97,7 +97,7 @@ defmodule Rollbax.Item do
     if map_size(custom) == 0 do
       data
     else
-      Map.put(data, "custom", custom)
+      Map.update(data, "custom", custom, &Map.merge(&1, custom))
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,8 +11,8 @@ defmodule ExUnit.RollbaxCase do
     end
   end
 
-  def start_rollbax_client(token, env) do
-    Rollbax.Client.start_link(token, env, true, "http://localhost:4004")
+  def start_rollbax_client(token, env, custom \\ %{}) do
+    Rollbax.Client.start_link(token, env, true, custom, "http://localhost:4004")
   end
 
   def ensure_rollbax_client_down(pid) do


### PR DESCRIPTION
Currently there's no way to set values for the rollbar `custom` field when using the Logger backend; [`post_event` hardcodes the custom fields to `%{}`](https://github.com/elixir-addicts/rollbax/blob/b2d460c1069c2d0f3f72ba19c5bead35349320c2/lib/rollbax/logger.ex#L97). (You can include metadata which is sent in the body of the message, but that's per-process metadata, you can't configure custom values once globally and have them be sent all the time). This PR lets you do eg `Logger.configure_backend(Rollbax.Logger, custom: %{site: ..., instance_id: ...})` to configure stuff which'll be sent in the custom field.

I'm happy to add a test once I know if you agree with the idea.