### PR TITLE
Fix global custom functionality

### DIFF
--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -17,8 +17,8 @@ defmodule Rollbax.Item do
         "platform" => platform(),
         "notifier" => notifier()
       }
+      |> put_custom(custom)
     }
-    |> put_custom(custom)
   end
 
   def compose(draft, {level, timestamp, body, custom, occurrence_data}) do


### PR DESCRIPTION
This is a bit embarrassing...

I've just gotten around to moving back onto mainline rollbax from my fork (now that the global custom thing had been merged into master, https://github.com/elixir-addicts/rollbax/pull/46). And found it doesn't work.

Turns out it was completely my fault - one of the last-minute tweaks I made in that PR before it was merged actually broke it (by putting the `custom` field in the outermost map rather than in the `data` member), and the tests I added didn't catch it (as they just checked that the data was somewhere in there with a regex, rather than parsing it). And I hadn't noticed till now as I was still on my original version.

This fixes that and makes the test actually test it. (Edit: tests moved to https://github.com/elixir-addicts/rollbax/pull/55)

Sorry about that :disappointed: