### PR TITLE
Correctly report :error values that are not exceptions

### DIFF
--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -122,13 +122,6 @@ defmodule Rollbax do
   @spec report(:error | :exit | :throw, any, [any], map, map) :: :ok
   def report(kind, value, stacktrace, custom \\ %{}, occurrence_data \\ %{})
   when kind in [:error, :exit, :throw] and is_list(stacktrace) and is_map(custom) and is_map(occurrence_data) do
-    # We need this manual check here otherwise Exception.format_banner(:error,
-    # term) will assume that term is an Erlang error (it will say
-    # "** # (ErlangError) ...").
-    if kind == :error and not Exception.exception?(value) do
-      raise ArgumentError, "expected an exception when the kind is :error, got: #{value}"
-    end
-
     body = Rollbax.Item.exception_to_body(kind, value, stacktrace)
     Rollbax.Client.emit(:error, unix_time(), body, custom, occurrence_data)
   end

--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -53,7 +53,8 @@ defmodule Rollbax.Item do
     %{"class" => "exit", "message" => Exception.format_exit(value)}
   end
 
-  defp exception(:error, exception) do
+  defp exception(:error, error) do
+    exception = Exception.normalize(:error, error)
     %{"class" => inspect(exception.__struct__), "message" => Exception.message(exception)}
   end
 

--- a/test/rollbax_test.exs
+++ b/test/rollbax_test.exs
@@ -28,6 +28,15 @@ defmodule RollbaxTest do
     refute body =~ ~s("custom")
   end
 
+  test "report/3 with an error that is not an exception" do
+    stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
+    error = {:badmap, nil}
+    :ok = Rollbax.report(:error, error, stacktrace, %{}, %{})
+    assert_receive {:api_request, body}
+    assert body =~ ~s("class":"BadMapError")
+    assert body =~ ~s("message":"expected a map, got: nil")
+  end
+
   test "report/3 with an exit" do
     stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
     :ok = Rollbax.report(:exit, :oops, stacktrace)


### PR DESCRIPTION
Right now, this:

```elixir
Rollbax.report(:error, term, ...)
```

raises an error when `term` is not an exception. However, this can happen quite easily: for example, when catching something in a `try`/`catch` construct, errors are not normalized so something like `{:badmap, term}` is not normalized to a `BadMapError` exception. With this commit, we stop enforcing exceptions when we report `:error` and we normalize errors later on.