### PR TITLE
Fix an infinite loop when client is not available

### DIFF
--- a/lib/rollbax/client.ex
+++ b/lib/rollbax/client.ex
@@ -32,7 +32,7 @@ defmodule Rollbax.Client do
       event = {Atom.to_string(level), timestamp, body, custom, occurrence_data}
       GenServer.cast(pid, {:emit, event})
     else
-      Logger.warn("(Rollbax) Trying to report an exception but the :rollbax application has not been started")
+      Logger.warn("(Rollbax) Trying to report an exception but the :rollbax application has not been started", rollbax: false)
     end
   end
 


### PR DESCRIPTION
The change prevents this log to be sent to Rollbax. Since the method is not a part of GenServer, `Logger.metadata(rollbax: false)` in init function wouldn't help. You should explicitly set `rollbax: false` here.

I encountered the issue when I was trying to understand what metadata is available in config and accidentally added `:pid` to the list. You will be able to reproduce the issue by setting this to config.

```
config :logger, Rollbax.Logger,
  level: :warn,
  metadata: [:file, :line, :module, :function, :pid]
```