### PR TITLE
Allow applications to modify occurrence_data when reporting through logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ Logger.metadata(rollbar: false)
 Logger.error("oops", rollbar: false)
 ```
 
+You can customize a message template with `occurrence\_func` option.
+It lets you to set a custom fingerprint and group occurrences into an item.
+
+```elixir
+# In config
+config :logger, Rollbax.Logger,
+  occurrence_func: &MyCustomOccurrence.compute/2
+
+# In your project
+defmodule MyCustomOccurrence do
+  def compute(message, metadata) do
+    fingerprint =
+      if metadata[:file] && metadata[:line] do
+        "logger:#{metadata[:file]}:#{metadata[:line]}"
+      else
+        # No file/line => maybe OTP message? Let's group with first line
+        [first_line|_] = String.split(message, "\n")
+        "logger:#{first_line}"
+      end
+
+    %{"fingerprint" => :crypto.hash(:sha, fingerprint) |> Base.encode16}
+  end
+end
+
+```
+
 For more information, check out the documentation for [`Rollbax.Logger`](http://hexdocs.pm/rollbax/Rollbax.Logger.html).
 
 ### Plug and Phoenix

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ It lets you to set a custom fingerprint and group occurrences into an item.
 # In config
 config :logger, Rollbax.Logger,
   occurrence_func: &MyCustomOccurrence.compute/2
+  # Or pass string if you use Distillery or Exrm
+  occurrence_func: "&MyCustomOccurrence.compute/2"
 
 # In your project
 defmodule MyCustomOccurrence do

--- a/lib/rollbax/logger.ex
+++ b/lib/rollbax/logger.ex
@@ -73,9 +73,9 @@ defmodule Rollbax.Logger do
     {:ok, state}
   end
 
-  def handle_event({level, _gl, event}, %{metadata: keys, blacklist: blacklist} = state) do
+  def handle_event({level, _gl, event}, %{metadata: keys, blacklist: blacklist, occurrence_func: occurrence_func} = state) do
     if proceed?(event) and meet_level?(level, state.level) do
-      post_event_unless_blacklisted(level, event, keys, blacklist)
+      post_event_unless_blacklisted(level, event, keys, blacklist, occurrence_func)
     end
     {:ok, state}
   end
@@ -94,14 +94,21 @@ defmodule Rollbax.Logger do
     Logger.compare_levels(level, min_level) != :lt
   end
 
-  defp post_event_unless_blacklisted(level, {Logger, message, event_time, metadata}, keys, blacklist) do
+  defp post_event_unless_blacklisted(level, {Logger, message, event_time, metadata}, keys, blacklist, occurrence_func) do
     event_unix_time = event_time_to_unix(event_time)
     message = message |> prune_chardata() |> IO.chardata_to_string()
     unless Enum.any?(blacklist, &(message =~ &1)) do
       metadata = Keyword.take(metadata, keys) |> Enum.into(%{})
       body = Rollbax.Item.message_to_body(message, metadata)
-      Rollbax.Client.emit(level, event_unix_time, body, %{}, %{})
+      occurrence = get_occurrence_data(message, metadata, occurrence_func)
+      Rollbax.Client.emit(level, event_unix_time, body, %{}, occurrence)
     end
+  end
+
+  defp get_occurrence_data(message, metadata, nil), do: %{}
+
+  defp get_occurrence_data(message, metadata, func) do
+    func.(message, metadata)
   end
 
   defp configure(opts) do
@@ -112,7 +119,8 @@ defmodule Rollbax.Logger do
 
     %{level: Keyword.get(config, :level, :error),
       metadata: Keyword.get(config, :metadata, []),
-      blacklist: Keyword.get(config, :blacklist, [])}
+      blacklist: Keyword.get(config, :blacklist, []),
+      occurrence_func: Keyword.get(config, :occurrence_func, nil)}
   end
 
   defp event_time_to_unix({{_, _, _} = date, {hour, min, sec, _millisec}}) do

--- a/lib/rollbax/logger.ex
+++ b/lib/rollbax/logger.ex
@@ -107,7 +107,12 @@ defmodule Rollbax.Logger do
 
   defp get_occurrence_data(message, metadata, nil), do: %{}
 
+  defp get_occurrence_data(message, metadata, func) when is_function(func) do
+    func.(message, metadata)
+  end
+
   defp get_occurrence_data(message, metadata, func) do
+    {func, _} = Code.eval_string(func)
     func.(message, metadata)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule Rollbax.Mixfile do
     [app: :rollbax,
      version: @version,
      elixir: "~> 1.1",
+     elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: description(),
@@ -34,6 +35,9 @@ defmodule Rollbax.Mixfile do
      {:plug,   "~> 1.0.0", only: :test},
      {:cowboy, "~> 1.0.0", only: :test}]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp description() do
     "Exception tracking and logging from Elixir to Rollbar"

--- a/test/rollbax/logger_test.exs
+++ b/test/rollbax/logger_test.exs
@@ -64,6 +64,21 @@ defmodule Rollbax.LoggerTest do
     assert body =~ ~s("foo":"bar")
   end
 
+  defmodule CustomOccurrence do
+    def get(_message, _metadata) do
+      %{"fingerprint" => "uniqueforitem"}
+    end
+  end
+
+  test "reporting with occurence_data" do
+    Logger.configure_backend(Rollbax.Logger, metadata: [:foo], occurrence_func: &CustomOccurrence.get/2)
+    capture_log(fn -> Logger.error("hello") end)
+    assert_receive {:api_request, body}
+
+    payload = Poison.decode!(body)
+    assert payload["data"]["fingerprint"] == "uniqueforitem"
+  end
+
   if Version.compare(System.version, "1.3.0-rc.1") != :lt do
     test "logging a message that has invalid unicode codepoints" do
       capture_log(fn -> Logger.error(["invalid:", ?\s, 1_000_000_000]) end)

--- a/test/support/custom_occurence.ex
+++ b/test/support/custom_occurence.ex
@@ -1,0 +1,5 @@
+defmodule CustomOccurrence do
+  def compute(_message, _metadata) do
+    %{"fingerprint" => "uniqueforitem"}
+  end
+end


### PR DESCRIPTION
We would like to group some logger events into one item with `fingerprint`.

https://rollbar.com/docs/custom-grouping/

This changes allow you to set fingerprint by customising `occurrent_data`.