### PR TITLE
Include the application name in stacktraces if available

### DIFF
--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -92,8 +92,8 @@ defmodule Rollbax.Item do
     formatted = Exception.format_mfa(module, fun, arity)
 
     case :application.get_application(module) do
-      {:ok, app} ->
-        formatted <> " (" <> Atom.to_string(app) <> ")"
+      {:ok, application} ->
+        formatted <> " (" <> Atom.to_string(application) <> ")"
       :undefined ->
         formatted
     end

--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -91,10 +91,11 @@ defmodule Rollbax.Item do
   defp format_mfa_and_app(module, fun, arity) do
     formatted = Exception.format_mfa(module, fun, arity)
 
-    if app = Application.get_application(module) do
-      formatted <> " (" <> Atom.to_string(app) <> ")"
-    else
-      formatted
+    case :application.get_application(module) do
+      {:ok, app} ->
+        formatted <> " (" <> Atom.to_string(app) <> ")"
+      :undefined ->
+        formatted
     end
   end
 

--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -69,13 +69,14 @@ defmodule Rollbax.Item do
   end
 
   def stacktrace_entry_to_frame({module, fun, arity, location}) when is_integer(arity) do
-    %{"method" => format_mfa_and_app(module, fun, arity)}
-    |> put_location(location)
+    method = Exception.format_mfa(module, fun, arity) <> maybe_format_application(module)
+    put_location(%{"method" => method}, location)
   end
 
   def stacktrace_entry_to_frame({module, fun, arity, location}) when is_list(arity) do
-    %{"method" => format_mfa_and_app(module, fun, length(arity)), "args" => Enum.map(arity, &inspect/1)}
-    |> put_location(location)
+    method = Exception.format_mfa(module, fun, arity) <> maybe_format_application(module)
+    args = Enum.map(arity, &inspect/1)
+    put_location(%{"method" => method, "args" => args}, location)
   end
 
   def stacktrace_entry_to_frame({fun, arity, location}) when is_integer(arity) do
@@ -88,14 +89,12 @@ defmodule Rollbax.Item do
     |> put_location(location)
   end
 
-  defp format_mfa_and_app(module, fun, arity) do
-    formatted = Exception.format_mfa(module, fun, arity)
-
+  defp maybe_format_application(module) do
     case :application.get_application(module) do
       {:ok, application} ->
-        formatted <> " (" <> Atom.to_string(application) <> ")"
+        " (" <> Atom.to_string(application) <> ")"
       :undefined ->
-        formatted
+        ""
     end
   end
 

--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -69,12 +69,12 @@ defmodule Rollbax.Item do
   end
 
   def stacktrace_entry_to_frame({module, fun, arity, location}) when is_integer(arity) do
-    %{"method" => Exception.format_mfa(module, fun, arity)}
+    %{"method" => format_mfa_and_app(module, fun, arity)}
     |> put_location(location)
   end
 
   def stacktrace_entry_to_frame({module, fun, arity, location}) when is_list(arity) do
-    %{"method" => Exception.format_mfa(module, fun, length(arity)), "args" => Enum.map(arity, &inspect/1)}
+    %{"method" => format_mfa_and_app(module, fun, length(arity)), "args" => Enum.map(arity, &inspect/1)}
     |> put_location(location)
   end
 
@@ -86,6 +86,16 @@ defmodule Rollbax.Item do
   def stacktrace_entry_to_frame({fun, arity, location}) when is_list(arity) do
     %{"method" => Exception.format_fa(fun, length(arity)), "args" => Enum.map(arity, &inspect/1)}
     |> put_location(location)
+  end
+
+  defp format_mfa_and_app(module, fun, arity) do
+    formatted = Exception.format_mfa(module, fun, arity)
+
+    if app = Application.get_application(module) do
+      formatted <> " (" <> Atom.to_string(app) <> ")"
+    else
+      formatted
+    end
   end
 
   defp put_location(frame, location) do


### PR DESCRIPTION
For now we have to bundle it in the "method" name, so that the JSON we report to Rollbar will look like:

    "method": "List.to_string/1 (elixir)"

because it's the only feasible place where we can put this in a "trace" object in the API. A screenshot of how it looks is here:

![](http://i.imgur.com/gMDANDT.png)