### PR TITLE
Use :inet_parse.ntoa/1 to get readable IP from tuple

### DIFF
--- a/pages/Using Rollbax in Plug-based applications.md
+++ b/pages/Using Rollbax in Plug-based applications.md
@@ -34,7 +34,7 @@ defp handle_errors(conn, %{kind: kind, reason: reason, stack: stacktrace}) do
     "request" => %{
       "cookies" => conn.req_cookies,
       "url" => "#{conn.scheme}://#{conn.host}:#{conn.port}#{conn.request_path}",
-      "user_ip" => (conn.remote_ip |> Tuple.to_list() |> Enum.join(".")),
+      "user_ip" => :inet_parse.ntoa(conn.remote_ip),
       "headers" => Enum.into(conn.req_headers, %{}),
       "params" => conn.params,
       "method" => conn.method,

--- a/pages/Using Rollbax in Plug-based applications.md
+++ b/pages/Using Rollbax in Plug-based applications.md
@@ -34,7 +34,7 @@ defp handle_errors(conn, %{kind: kind, reason: reason, stack: stacktrace}) do
     "request" => %{
       "cookies" => conn.req_cookies,
       "url" => "#{conn.scheme}://#{conn.host}:#{conn.port}#{conn.request_path}",
-      "user_ip" => :inet_parse.ntoa(conn.remote_ip),
+      "user_ip" => List.to_string(:inet_parse.ntoa(conn.remote_ip)),
       "headers" => Enum.into(conn.req_headers, %{}),
       "params" => conn.params,
       "method" => conn.method,


### PR DESCRIPTION
* IPv4: `conn.remote_ip = {127,0,0,1}`
  --> Before: `"127.0.0.1"`
  -->  After: `"127.0.0.1"`

* IPv6: `conn.remote_ip = {8194,28109,35956,25857,4018,1564,44184,1726}`
  --> Before: `"8194.28109.35956.25857.4018.1564.44184.1726"`
  -->  After: `"2002:6DCD:8C74:6501:FB2:61C:AC98:6BE"`