### PR TITLE
[item] Fixing `draft` override `ocurrence_data`

### DIFF
--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -23,8 +23,8 @@ defmodule Rollbax.Item do
 
   def compose(draft, {level, timestamp, body, custom, occurrence_data}) do
     Map.update!(draft, "data", fn(data) ->
-      occurrence_data
-      |> Map.merge(data)
+      data
+      |> Map.merge(occurrence_data)
       |> Map.put("body", body)
       |> put_custom(custom)
       |> Map.put("level", level)

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Rollbax.Mixfile do
      description: description(),
      package: package(),
      deps: deps(),
+     aliases: aliases(),
      name: "Rollbax",
      docs: [main: "Rollbax",
             source_ref: "v#{@version}",
@@ -42,5 +43,11 @@ defmodule Rollbax.Mixfile do
     [maintainers: ["Aleksei Magusev", "Andrea Leopardi"],
      licenses: ["ISC"],
      links: %{"GitHub" => "https://github.com/elixir-addicts/rollbax"}]
+  end
+
+  defp aliases do
+    [
+      "test": "test --no-start",
+    ]
   end
 end

--- a/test/rollbax/client_test.exs
+++ b/test/rollbax/client_test.exs
@@ -17,8 +17,18 @@ defmodule Rollbax.ClientTest do
 
   test "emit/5" do
     custom = %{foo: "bar"}
-    :ok = Client.emit(:warn, unix_time(), %{"message" => %{"body" => "pass"}}, custom, %{})
+    occurrence_data = %{
+      "server" => %{
+        "host" => "custom.host",
+        "code_version" => "v1111",
+      }
+    }
+
+    :ok = Client.emit(:warn, unix_time(), %{"message" => %{"body" => "pass"}}, custom, occurrence_data)
     assert_receive {:api_request, body}
+
+    assert body =~ ~s("host":"custom.host")
+    assert body =~ ~s("code_version":"v1111")
     assert body =~ ~s("access_token":"token1")
     assert body =~ ~s("environment":"test")
     assert body =~ ~s("level":"warn")


### PR DESCRIPTION
information related to `server` of the `ocurrence_data` is overwritten by the `draft`. This forbid the customization of the `server` informations.