### PR TITLE
Adding support for all Rollbar's levels and raw messages

### DIFF
--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -59,7 +59,11 @@ defmodule Rollbax.Item do
     %{"class" => "exit", "message" => message}
   end
 
-  defp exception(:error, error) do
+  defp exception(_, message) when is_binary(message) do
+    %{"message" => message}
+  end
+
+  defp exception(_, error) do
     exception = Exception.normalize(:error, error)
     %{"class" => inspect(exception.__struct__), "message" => Exception.message(exception)}
   end

--- a/test/rollbax_test.exs
+++ b/test/rollbax_test.exs
@@ -37,6 +37,51 @@ defmodule RollbaxTest do
     assert body =~ ~s("message":"expected a map, got: nil")
   end
 
+  test "report/3 with an error that is a message" do
+    stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
+    error = "Something was wrong"
+    :ok = Rollbax.report(:error, error, stacktrace, %{}, %{})
+    assert_receive {:api_request, body}
+    assert body =~ ~s("level":"error")
+    assert body =~ ~s("message":"Something was wrong")
+  end
+
+  test "report/3 with an debug that is a message" do
+    stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
+    message = "Settings saved"
+    :ok = Rollbax.report(:debug, message, stacktrace, %{}, %{})
+    assert_receive {:api_request, body}
+    assert body =~ ~s("level":"debug")
+    assert body =~ ~s("message":"Settings saved")
+  end
+
+  test "report/3 with an info that is a message" do
+    stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
+    message = "Login successful"
+    :ok = Rollbax.report(:info, message, stacktrace, %{}, %{})
+    assert_receive {:api_request, body}
+    assert body =~ ~s("level":"info")
+    assert body =~ ~s("message":"Login successful")
+  end
+
+  test "report/3 with an warning that is a message" do
+    stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
+    message = "Unexpected input"
+    :ok = Rollbax.report(:warning, message, stacktrace, %{}, %{})
+    assert_receive {:api_request, body}
+    assert body =~ ~s("level":"warning")
+    assert body =~ ~s("message":"Unexpected input")
+  end
+
+  test "report/3 with an critical that is a message" do
+    stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
+    error = "Something is broken"
+    :ok = Rollbax.report(:critical, error, stacktrace, %{}, %{})
+    assert_receive {:api_request, body}
+    assert body =~ ~s("level":"critical")
+    assert body =~ ~s("message":"Something is broken")
+  end
+
   test "report/3 with an exit" do
     stacktrace = [{Test, :report, 2, [file: 'file.exs', line: 16]}]
     :ok = Rollbax.report(:exit, :oops, stacktrace)


### PR DESCRIPTION
Allow to send debug/info/warning messages to Rollbar.

```elixir
Rollbax.report(:warning, "Unexpected input", System.stacktrace())
```