### PR TITLE
Support a custom Rollbar API endpoint

### DIFF
--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -30,6 +30,8 @@ defmodule Rollbax do
       individual call to `Rollbax.report/5` it will be merged with the global
       data, with the individual data taking precedence in case of conflicts.
       Defaults to `%{}`.
+    * `:api_endpoint` - (binary) the rollbar endpoint to report exceptions to.
+      Defaults to `https://api.rollbar.com/api/1/item/`.
 
   The `:access_token` and `:environment` options accept a binary or a
   `{:system, "VAR_NAME"}` tuple. When given a tuple like `{:system, "VAR_NAME"}`,
@@ -44,10 +46,13 @@ defmodule Rollbax do
 
   use Application
 
+  @default_api_endpoint "https://api.rollbar.com/api/1/item/"
+
   @doc false
   def start(_type, _args) do
     enabled = Application.get_env(:rollbax, :enabled, true)
     custom = Application.get_env(:rollbax, :custom, %{})
+    api_endpoint = Application.get_env(:rollbax, :api_endpoint, @default_api_endpoint)
     environment = resolve_system_env(Application.fetch_env!(:rollbax, :environment))
 
     access_token =
@@ -61,7 +66,7 @@ defmodule Rollbax do
     end
 
     children = [
-      Supervisor.Spec.worker(Rollbax.Client, [access_token, environment, enabled, custom])
+      Supervisor.Spec.worker(Rollbax.Client, [access_token, environment, enabled, custom, api_endpoint])
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -66,7 +66,7 @@ defmodule Rollbax do
     end
 
     children = [
-      Supervisor.Spec.worker(Rollbax.Client, [access_token, environment, enabled, custom, api_endpoint])
+      Supervisor.Spec.worker(Rollbax.Client, [api_endpoint, access_token, environment, enabled, custom])
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)

--- a/lib/rollbax/client.ex
+++ b/lib/rollbax/client.ex
@@ -15,7 +15,6 @@ defmodule Rollbax.Client do
 
   @name __MODULE__
   @hackney_pool __MODULE__
-  @api_url "https://api.rollbar.com/api/1/item/"
   @headers [{"content-type", "application/json"}]
 
   ## GenServer state
@@ -24,7 +23,7 @@ defmodule Rollbax.Client do
 
   ## Public API
 
-  def start_link(access_token, environment, enabled, custom, url \\ @api_url) do
+  def start_link(access_token, environment, enabled, custom, url) do
     state = %__MODULE__{
       draft: Item.draft(access_token, environment, custom),
       url: url,

--- a/lib/rollbax/client.ex
+++ b/lib/rollbax/client.ex
@@ -23,10 +23,10 @@ defmodule Rollbax.Client do
 
   ## Public API
 
-  def start_link(access_token, environment, enabled, custom, url) do
+  def start_link(api_endpoint, access_token, environment, enabled, custom) do
     state = %__MODULE__{
       draft: Item.draft(access_token, environment, custom),
-      url: url,
+      url: api_endpoint,
       enabled: enabled,
     }
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,7 +12,7 @@ defmodule ExUnit.RollbaxCase do
   end
 
   def start_rollbax_client(token, env, custom \\ %{}) do
-    Rollbax.Client.start_link(token, env, true, custom, "http://localhost:4004")
+    Rollbax.Client.start_link("http://localhost:4004", token, env, _enabled = true, custom)
   end
 
   def ensure_rollbax_client_down(pid) do


### PR DESCRIPTION
The Rollbar client already accepts a URL as an optional argument but nothing is passing in that argument so it just uses the default value. This adds a new `endpoint` configuration parameter that has the same default value and gets passed into the client.

/cc @lexmag @whatyouhide 