### PR TITLE
use a regex when checking stack traces

### DIFF
--- a/test/rollbax/logger_test.exs
+++ b/test/rollbax/logger_test.exs
@@ -216,7 +216,7 @@ defmodule Rollbax.LoggerTest do
       }
 
       assert [frame] = find_frames_for_current_file(data["body"]["trace"]["frames"])
-      assert frame["method"] == ~s[anonymous fn/0 in Rollbax.LoggerTest."test process raising an error"/1]
+      assert frame["method"] =~ ~r[anonymous fn/0 in Rollbax.LoggerTest.(\")?test process raising an error(\")?/1]
 
       assert data["custom"] == %{"pid" => inspect(pid)}
     end)
@@ -234,7 +234,7 @@ defmodule Rollbax.LoggerTest do
       }
 
       assert [frame] = find_frames_for_current_file(data["body"]["trace"]["frames"])
-      assert frame["method"] == ~s[anonymous fn/0 in Rollbax.LoggerTest."test task with anonymous function raising an error"/1]
+      assert frame["method"] =~ ~r[anonymous fn/0 in Rollbax.LoggerTest.(\")?test task with anonymous function raising an error(\")?/1]
 
       assert data["custom"]["name"] == inspect(task)
       assert data["custom"]["function"] =~ ~r/\A#Function<.* in Rollbax\.LoggerTest/


### PR DESCRIPTION
The way a stack traces displays a method name seems to have changed between
Elixir version 1.4 and 1.5. Method names that contain spaces will now be
wrapped in quotes, but they were not in 1.4. This causes two tests to fail
because they are expected quotes that don't exist in Elixir versions prior to
1.5. Using this regex, we make the quotes optional to support multiple elixir
versions.

/cc @lexmag @whatyouhide 