### PR TITLE
Creating Map from params excluding passwords

### DIFF
--- a/pages/Using Rollbax in Plug-based applications.md
+++ b/pages/Using Rollbax in Plug-based applications.md
@@ -70,7 +70,7 @@ defp handle_errors(conn, error) do
       else
         tuple
       end
-    end
+    end |> Map.new()
 
   # Same as the examples above
 end


### PR DESCRIPTION
This is causing an error on Rollbax parsing the path params:

```
[error] (Rollbax) failed to encode report below for reason: unable to encode value: {"path_param_key", "path_param_value"}
```