### PR TITLE
Don't set arity in method name

### DIFF
--- a/lib/rollbax/item.ex
+++ b/lib/rollbax/item.ex
@@ -103,7 +103,7 @@ defmodule Rollbax.Item do
   end
 
   defp stacktrace_entry_to_frame({module, fun, arity, location}) when is_list(arity) do
-    method = Exception.format_mfa(module, fun, arity) <> maybe_format_application(module)
+    method = Exception.format_mfa(module, fun, length(arity)) <> maybe_format_application(module)
     args = Enum.map(arity, &inspect/1)
     put_location(%{"method" => method, "args" => args}, location)
   end


### PR DESCRIPTION
The method name in stacktrace is used by Rollbar for their default fingerprint calculation.

https://rollbar.com/docs/grouping-algorithm/

Adding arity to the method name breaks grouping logic and we have issues for each argument pattern.

For example, add the following methods to your Phoenix controller.

```elixir
  def hello(conn, %{"name" => name}) do
    greeting = say_hello(name)
    text conn, greeting
  end

  defp say_hello(conn, "John"), do: "Hello John"
```

Try calling the endpoint with different names e.g. `/hello?name=Sakura`, `/hello?name=Naruto`.
You would expect you see one `FunctionClauseError` for two occurrences on Rollbar but each will have separate Rollbar issues.

Since you already set arity to argument and Rollbar shows it nicely, you don't need to set it to the method name. This PR fixes the issue and Rollbar can group them properly.