### PR TITLE
Improve documentation surrounding old config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ config :rollbax, enable_crash_reports: true
 ```
 
 For more information, check out the documentation for [`Rollbax.Logger`](http://hexdocs.pm/rollbax/Rollbax.Logger.html).
+If you had previously configured the logger with a `Rollbax.Logger` backend e.g. (`config :logger, backends: [:console, Rollbax.Logger]`) you will need to remove this.
 
 ### Plug and Phoenix
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ config :rollbax, enable_crash_reports: true
 ```
 
 For more information, check out the documentation for [`Rollbax.Logger`](http://hexdocs.pm/rollbax/Rollbax.Logger.html).
-If you had previously configured the logger with a `Rollbax.Logger` backend e.g. (`config :logger, backends: [:console, Rollbax.Logger]`) you will need to remove this.
+If you had previously configured `Rollbax.Logger` to be a Logger backend (for example `config :logger, backends: [Rollbax.Logger]`), you will need to remove since `Rollbax.Logger` is not a Logger backend anymore and you will get crashes if you use it as such.
 
 ### Plug and Phoenix
 

--- a/lib/rollbax/logger.ex
+++ b/lib/rollbax/logger.ex
@@ -11,7 +11,9 @@ defmodule Rollbax.Logger do
 
       config :rollbax, :enable_crash_reports, true
 
-  All the configuration options for reporting crashes are documented in detail below.
+  All the configuration options for reporting crashes are documented in detail below. If you are
+  upgrading from an older version of Rollbax that used this module as a logger backend via
+  `config :logger, backends: [:console, Rollbax.Logger]` this config should be removed.
 
   `Rollbax.Logger` implements a mechanism of reporting based on *reporters*, which are modules
   that implement the `Rollbax.Reporter` behaviour. Every message received by `Rollbax.Logger` is


### PR DESCRIPTION
Prior to `0.9` the `Rollax.Logger` module was used as backend to the normal logger, upgrading breaks this and provides an improved alternative. This PR tries to improve the documentation surrounding this.