### PR TITLE
Replace poison with jason in applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Rollbax.Mixfile do
   end
 
   def application() do
-    [applications: [:logger, :hackney, :poison], env: env(), mod: {Rollbax, []}]
+    [applications: [:logger, :hackney, :jason], env: env(), mod: {Rollbax, []}]
   end
 
   defp deps() do


### PR DESCRIPTION
When running a release

```
** (UndefinedFunctionError) function Jason.encode_to_iodata/1 is undefined (module Jason is not available)
```